### PR TITLE
Update .htaccess

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -4,12 +4,12 @@ RewriteCond %{REQUEST_FILENAME} !-d
 RewriteCond %{REQUEST_FILENAME}\.php -f
 RewriteRule ^(.*)$ $1.php
 
-# HTTP Domain Redirects
+# HTTP Domain Redirects (Now using "Redirect permanent / https://peercoin.net/" in Apache's VirtualHost with aliases for net com org)
 # RewriteCond %{HTTP_HOST}    !^peercoin\.net [NC]
 # RewriteCond %{HTTP_HOST}    !^$
 # RewriteRule ^/(.*)  http://peercoin.net/$1 [L,R=301]
 
-# HTTP to HTTPS rewrite		
+# HTTP to HTTPS rewrite	(Now using "Redirect permanent / https://peercoin.net/" in Apache's VirtualHost with aliases for net com org)
 # RewriteCond %{HTTPS} off		
 # RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI} [R=301,L]
 


### PR DESCRIPTION
The redirect for .net, .org, .com, www., is now set up in sites-available on the apache server including http to https. This gives us more flexibility with the 301 redirects especially when we start using sub domains (talk.peercoin.net, etc.). Redirects in htaccess file are no longer needed.